### PR TITLE
dockerize the app and add some install instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:12
+
+RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
+
+WORKDIR /home/node/app
+
+COPY package*.json ./
+
+USER node
+
+RUN npm install
+
+COPY --chown=node:node . .
+
+EXPOSE 6006
+
+# CMD [ "node", "app.js" ]
+ENTRYPOINT /bin/bash

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # sakai-web-components
+
+## Setup with Docker
+
+Run the following commands to get up and running if you have Docker and Docker Compose installed.
+
+` docker-compose run --rm --service-ports node`
+
+Your CLI will then be in the container and your prompt should change to something like `node@asdf123:~/app$`
+
+You can then run these commands from inside the container
+
+`npm install`
+
+`npm run storybook`
+
+You should be able to visit [http://localhost:6006](http://localhost:6006) and see the storybook interface.
+
+ctrl+c will end the storybook server and typing `exit` will return you to your normal CLI prompt.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  node:
+    build: .
+    container_name: sakai-web-components
+    # user: "node"
+    # working_dir: /home/node/app
+    # environment:
+      # - NODE_ENV=production
+      # - NPM_CONFIG_LOGLEVEL=info
+    volumes:
+      - ./:/home/node/app
+    ports:
+      - 6006:6006


### PR DESCRIPTION
I'm trying to keep my dev machine more containerized and added some docker stuff. I'm out of the loop on actual component development so didn't add any instructions past the setup stage but it seems like it should be fully compatible.

The beauty of this approach is that we shouldn't have to worry about new devs coming on board and what their machine looks like. If we have everyone go through docker we can control all those variables from within the dockerfile and docker-compose.